### PR TITLE
Fix warnings and errors

### DIFF
--- a/src/HtmlToRtf.php
+++ b/src/HtmlToRtf.php
@@ -1,6 +1,7 @@
 <?php
 namespace HtmlToRtf;
 
+use DOMDocument;
 use HtmlToRtf\Node;
 
 // References:
@@ -23,7 +24,7 @@ class HtmlToRtf
 
     public function __construct($html)
     {
-        $this->_doc = new \DOMDocument();
+        $this->_doc = new DOMDocument();
         $this->setHtml($html);
     }
 
@@ -61,14 +62,14 @@ class HtmlToRtf
 
     private function removeEmptyTextNodes($DOMNode)
     {
-        if(!($DOMNode instanceof DOMNode)){
+        if(!($DOMNode instanceof DOMNode)) {
             return;
         }
 
-        if($DOMNode instanceof DOMText && trim($DOMNode->nodeValue) === ''){
+        if($DOMNode instanceof DOMText && trim($DOMNode->nodeValue) === '') {
             $this->removeEmptyTextNodes($DOMNode->nextSibling);
             $DOMNode->parentNode->removeChild($DOMNode);
-        }else{
+        } else {
             $this->removeEmptyTextNodes($DOMNode->nextSibling);
             $this->removeEmptyTextNodes($DOMNode->firstChild);
         }

--- a/src/Node.php
+++ b/src/Node.php
@@ -1,6 +1,8 @@
 <?php
 namespace HtmlToRtf;
 
+use DOMElement;
+use DOMNode;
 use HtmlToRtf\Node\TextNode;
 use HtmlToRtf\Node\NotSupportedNode;
 use HtmlToRtf\Node\ElementNode;
@@ -21,9 +23,9 @@ class Node
     private $_domNode;
 
     /**
-     * @param DOMNode $node
+     * @param DOMNode $aDomNode
      */
-    public function __construct($aDomNode)
+    public function __construct(DOMNode $aDomNode)
     {
         $this->_domNode = $aDomNode;
     }

--- a/src/Node/ElementNode.php
+++ b/src/Node/ElementNode.php
@@ -36,9 +36,15 @@ class ElementNode extends Node
         return $this->_attributes;
     }
 
-    public function getAttribute($name){ return $this->getAttributes()[$name]; }
-    protected function setRtfPrepend($rtf){ $this->_rtfPrepend = $rtf; }
-    protected function setRtfAppend($rtf){ $this->_rtfAppend = $rtf; }
+    public function getAttribute($name) {
+        return $this->getAttributes()[$name] ?? null;
+    }
+    protected function setRtfPrepend($rtf) {
+        $this->_rtfPrepend = $rtf;
+    }
+    protected function setRtfAppend($rtf) {
+        $this->_rtfAppend = $rtf;
+    }
     /**
      * @return string
      */

--- a/src/Node/ElementNode/ListElementNode.php
+++ b/src/Node/ElementNode/ListElementNode.php
@@ -2,6 +2,7 @@
 namespace HtmlToRtf\Node\ElementNode;
 
 use HtmlToRtf\Node\ElementNode;
+use HtmlToRtf\Node\ElementNode\ListElementNode\LIElementNode;
 
 class ListElementNode extends ElementNode
 {

--- a/src/Node/ElementNode/ListElementNode/LIElementNode.php
+++ b/src/Node/ElementNode/ListElementNode/LIElementNode.php
@@ -3,6 +3,7 @@ namespace HtmlToRtf\Node\ElementNode\ListElementNode;
 
 use HtmlToRtf\Node;
 use HtmlToRtf\Node\ElementNode;
+use HtmlToRtf\Node\ElementNode\ListElementNode;
 
 class LIElementNode extends ElementNode
 {

--- a/src/Node/ElementNode/PElementNode.php
+++ b/src/Node/ElementNode/PElementNode.php
@@ -17,7 +17,9 @@ class PElementNode extends ElementNode
         $styles = array_map('trim',$styles);
         foreach($styles as $styleDef)
         {
-            if(empty($styleDef)){ continue; }
+            if(empty($styleDef)) {
+                continue;
+            }
 
             $style = preg_split('/:/',$styleDef);
             $style = array_map('trim',$style);
@@ -45,7 +47,7 @@ class PElementNode extends ElementNode
                     break;
             }
         }
-        $this->setRtfPrepend($prepend.' ');
+        $this->setRtfPrepend($prepend . ' ');
         $this->setRtfAppend($append);
 
         return parent::parse();

--- a/src/Node/ElementNode/SpanElementNode.php
+++ b/src/Node/ElementNode/SpanElementNode.php
@@ -39,7 +39,7 @@ class SpanElementNode extends ElementNode
                     break;
             }
         }
-        $this->setRtfPrepend(count($prepend) > 0 ? $prepend.' ' : $prepend);
+        $this->setRtfPrepend(strlen($prepend) > 0 ? $prepend . ' ' : $prepend);
         $this->setRtfAppend($append);
 
         return parent::parse();

--- a/src/Node/NotSupportedNode.php
+++ b/src/Node/NotSupportedNode.php
@@ -6,5 +6,7 @@ use HtmlToRtf\Node;
 class NotSupportedNode extends Node
 {
     //do nothing
-    public function parse(){ return ''; }
+    public function parse() {
+        return '';
+    }
 }

--- a/src/Node/TextNode.php
+++ b/src/Node/TextNode.php
@@ -1,14 +1,17 @@
 <?php
 namespace HtmlToRtf\Node;
 
+use DOMNode;
 use HtmlToRtf\Node;
 
 class TextNode extends Node
 {
     /**
-     * @return DOMText
+     * @return DOMNode
      */
-    protected function getDomNode(){ return parent::getDomNode(); }
+    protected function getDomNode() {
+        return parent::getDomNode();
+    }
 
     /**
      * @return string


### PR DESCRIPTION
This commit addresses the issue: #2

In detail:
- add handling of the "array offset" Notice:
`Notice: Trying to access array offset on value of type null in src\Node\ElementNode.php on line 39.` 
- add handling "count" warning:
`Warning: count(): Parameter must be an array or an object that implements Countable in src\Node\ElementNode\SpanElementNode.php on line 42.`